### PR TITLE
add 3 levels of prototypes to Feature.prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,13 @@ function stubService(service) {
   var client = new Original();
 
   function FakeService(config) { Object.assign(this, new Original(config)); }
-  FakeService.prototype = Object.assign({}, client.__proto__);
+  FakeService.prototype = Object.assign(
+    {},
+    client.__proto__.__proto__.__proto__,
+    client.__proto__.__proto__,
+    client.__proto__
+  );
+
 
   var spy = sinon.spy(FakeService);
   spy.restore = function() { setService(service, Original); };

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ function stubService(service) {
     client.__proto__
   );
 
-
   var spy = sinon.spy(FakeService);
   spy.restore = function() { setService(service, Original); };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -233,3 +233,23 @@ test('[multipleMethods] replacement function', function(assert) {
     assert.end();
   });
 });
+
+test('[upload] methods inherited multiple times', function(assert) {
+  var upload = AWS.stub('S3', 'upload', function(params, callback) {
+    callback(null, data);
+  });
+
+  app.upload(function(err, data) {
+    assert.ifError(err, 'success');
+    assert.equal(data, 'hello world');
+
+    assert.equal(AWS.S3.callCount, 1, 'one s3 client created');
+    assert.ok(AWS.S3.calledWithExactly({ region }), 's3 client created for the correct region');
+
+    assert.equal(upload.callCount, 1, 'called s3.upload once');
+    assert.ok(upload.calledWith(expected), 'called s3.upload with expected params');
+
+    AWS.S3.restore();
+    assert.end();
+  });
+});

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,6 +1,6 @@
 var AWS = require('aws-sdk');
 
-module.exports = { useCallback, usePromise, streaming, useEvents, multipleMethods };
+module.exports = { useCallback, usePromise, streaming, useEvents, multipleMethods, upload };
 
 function useCallback(callback) {
   var s3 = new AWS.S3({ region: 'eu-west-1' });
@@ -46,4 +46,12 @@ function multipleMethods(callback) {
     .then(function() { return get; })
     .then(function(data) { callback(null, data.Body.toString()); })
     .catch(callback);
+}
+
+function upload(callback) {
+  var s3 = new AWS.S3({ region: 'eu-west-1' });
+  s3.upload({ Bucket: 'bucket', Key: 'key' }, function(err, data) {
+    if (err) return callback(err);
+    callback(null, data.Body.toString());
+  });
 }


### PR DESCRIPTION
allows stubbing of s3.upload and other previously unavailable methods.

@rclark this approach seems janky, but includes all the `__proto__` in the current version of the aws-sdk. it's not very future proof in that future aws-sdk versions could go deeper, but this was easier than writing some recursive function.

edit: i dont _think_ there's any harm if a service object has inheretied fewer `__proto__`? worst case we're Object.assigning the non-existent properties from an empty object prototype? 
