### PR TITLE
added extra argument to stub method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .nyc_output/
 coverage/
+.idea/

--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ function stubMethod(service, method, replacement) {
   if (!isStubbed(service)) stubService(service);
   if (!replacement) return sinon.stub(getService(service).prototype, method);
 
-  return sinon.stub(getService(service).prototype, method).callsFake(function(params, callback) {
+  return sinon.stub(getService(service).prototype, method).callsFake(function(arg1, arg2, arg3) {
     var _this = { request: stubRequest(), response: stubResponse() };
-    replacement.call(_this, params, callback);
+    replacement.call(_this, arg1, arg2, arg3);
     return _this.request;
   });
 }


### PR DESCRIPTION
added extra argument to stub method as some AWS sdk methods take more than 2 arguments e.g waitFor(state, params = {}, callback)