### PR TITLE
upgrade sinon to 4.4.9

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 1.0.0
+
+- Update to sinon v4.4.9 #11
+
 ### 0.0.5
 
 - Update dependencies #7

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.84.0",
-    "sinon": "^2.3.8",
+    "sinon": "^5.0.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.84.0",
-    "sinon": "^5.0.0",
+    "sinon": "^4.4.9",
     "traverse": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
fixes #9 

- tests pass locally
- tested in two projects that use mock-aws-sdk-js for their tests, and those went swimmingly 

i looked over the "migrating to sinon 3/4" docs, and im not 100% certain that incrementing the sinon version should result in a major release for mock-aws-sdk-js. 
- http://sinonjs.org/guides/migrating-to-3.0
- http://sinonjs.org/guides/migrating-to-4.0 